### PR TITLE
test for target directory

### DIFF
--- a/src/main/groovy/com/github/voplex95/plugin/lesscompiler/tasks/lesscompile/LessCompileTask.groovy
+++ b/src/main/groovy/com/github/voplex95/plugin/lesscompiler/tasks/lesscompile/LessCompileTask.groovy
@@ -40,8 +40,10 @@ class LessCompileTask extends DefaultTask {
 
         for(lessFile in listMatches()) {
             def compiledContent = Less.compile((File)lessFile, compress)
-            def destinationPath = target.isFile() ? target.absolutePath :
-                    target.absolutePath + File.separator + composeCssFileName(((File)lessFile).name)
+            def destinationPath = target.absolutePath
+            if(destinationPath.isDirectory()) {
+               destinationPath = new File(destinationPath, composeCssFileName(((File)lessFile).name))
+            }
 
             PrintWriter writer = new PrintWriter(destinationPath, "UTF-8")
             writer.print(compiledContent)

--- a/src/main/groovy/com/github/voplex95/plugin/lesscompiler/tasks/lesscompile/LessCompileTask.groovy
+++ b/src/main/groovy/com/github/voplex95/plugin/lesscompiler/tasks/lesscompile/LessCompileTask.groovy
@@ -41,7 +41,7 @@ class LessCompileTask extends DefaultTask {
         for(lessFile in listMatches()) {
             def compiledContent = Less.compile((File)lessFile, compress)
             def destinationPath = target.absolutePath
-            if(destinationPath.isDirectory()) {
+            if(target.isDirectory()) {
                destinationPath = new File(destinationPath, composeCssFileName(((File)lessFile).name))
             }
 


### PR DESCRIPTION
The code only used `target` "as-is" if it was a file.  This forces users who want to
compile a single file to a single target file to make sure that the target file exists.

This commit changes that to only write to a new file if the target is a directory.